### PR TITLE
BigInt does not have a parseInt method, use BigInt() instead

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = function(Parser) {
       }
 
       let str = this.input.slice(start, this.pos)
-      let val = typeof BigInt !== "undefined" && BigInt.parseInt ? BigInt.parseInt(str) : null
+      let val = typeof BigInt !== "undefined" ? BigInt(str) : null
       ++this.pos
       return this.finishToken(tt.num, val)
     }


### PR DESCRIPTION
There is a proposal for `BigInt.fromString` but it's only stage 1 and nothing implements it yet.