### PR TITLE
Migrate to ESM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+dist/
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.410 (2020-05-14)
+
+* Migrate to ESM
+
 ## 0.4.0 (2019-04-04)
 
 * Make compatible with acorn-numeric-separator

--- a/README.md
+++ b/README.md
@@ -8,11 +8,20 @@ It implements support for arbitrary precision integers as defined in the stage 3
 
 ## Usage
 
-This module provides a plugin that can be used to extend the Acorn `Parser` class:
+This module provides a plugin that can be used to extend the Acorn `Parser` class.
+You can either choose to use it via CommonJS (for example in Node.js) like this
 
 ```javascript
 const {Parser} = require('acorn');
 const bigInt = require('acorn-bigint');
+Parser.extend(bigInt).parse('100n');
+```
+
+or as an ECMAScript module like this:
+
+```javascript
+import {Parser} from 'acorn';
+import bigInt from 'path/to/acorn-bigint.mjs';
 Parser.extend(bigInt).parse('100n');
 ```
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "contributors": [
     "Adrian Heine <mail@adrianheine.de>"
   ],
+  "main": "dist/acorn-bigint.js",
+  "module": "dist/acorn-bigint.mjs",
   "engines": {
     "node": ">=4.8.2"
   },
@@ -14,6 +16,8 @@
   },
   "license": "MIT",
   "scripts": {
+    "build": "rollup -c rollup.config.js",
+    "prepare": "npm run build",
     "test": "mocha",
     "test:test262": "node run_test262.js",
     "lint": "eslint -c .eslintrc.json ."
@@ -21,12 +25,13 @@
   "peerDependencies": {
     "acorn": "^6.0.0"
   },
-  "version": "0.4.0",
+  "version": "0.4.1",
   "devDependencies": {
     "acorn": "^6.1.1",
     "eslint": "^5.16.0",
     "eslint-plugin-node": "^8.0.1",
     "mocha": "^6.0.2",
+    "rollup": "^2.10.0",
     "test262": "git+https://github.com/tc39/test262.git#611919174ffe060503691a0c7e3eb2a65b646124",
     "test262-parser-runner": "^0.5.0"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,15 @@
+export default {
+  input: "src/index.js",
+  output: [
+    {
+      file: "dist/acorn-bigint.js",
+      format: "cjs",
+      sourcemap: true
+    },
+    {
+      file: "dist/acorn-bigint.mjs",
+      format: "es",
+      sourcemap: true
+    }
+  ]
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,8 @@
-"use strict"
+export default function bigInt(Parser) {
+  const acorn = Parser.acorn || require("acorn")
+  const tt = acorn.tokTypes
+  const isIdentifierStart = acorn.isIdentifierStart
 
-const acorn = require("acorn")
-const tt = acorn.tokTypes
-const isIdentifierStart = acorn.isIdentifierStart
-
-module.exports = function(Parser) {
   return class extends Parser {
     parseLiteral(value) {
       const node = super.parseLiteral(value)


### PR DESCRIPTION
We've recently migrated Chrome DevTools to ESM, and have traditionally
been using acorn as the parser for various features including the
prettifier. In the context of https://crbug.com/1009927 we are looking
into including BigInt support in Chrome DevTools via this plugin, and
in order to make that easier with our build system, I've added support
for ESM output here in addition to the CJS output (together with
@TimvdLippe).